### PR TITLE
Add standard for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on: push
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - run: bundle exec standardrb

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,3 @@
+fix: false
+parallel: false
+format: progress

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in static_association.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
 require "bundler/gem_tasks"
-require 'rspec/core/rake_task'
-require 'appraisal'
+require "rspec/core/rake_task"
+require "appraisal"
+require "standard/rake"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: [:standard, :spec]

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -1,13 +1,14 @@
-require 'static_association/version'
-require 'active_support/concern'
-require 'active_support/core_ext/module/delegation'
-require 'active_support/core_ext/hash/keys'
-require 'active_support/core_ext/string/inflections'
+require "static_association/version"
+require "active_support/concern"
+require "active_support/core_ext/module/delegation"
+require "active_support/core_ext/hash/keys"
+require "active_support/core_ext/string/inflections"
 
 module StaticAssociation
   extend ActiveSupport::Concern
 
   class DuplicateID < StandardError; end
+
   class RecordNotFound < StandardError; end
 
   attr_reader :id
@@ -24,7 +25,7 @@ module StaticAssociation
     delegate :each, to: :all
 
     def index
-      @index ||= {} 
+      @index ||= {}
     end
 
     def all
@@ -43,8 +44,8 @@ module StaticAssociation
       settings.assert_valid_keys(:id)
       id = settings.fetch(:id)
       raise DuplicateID if index.has_key?(id)
-      record = self.new(id)
-      record.instance_exec(record, &block) if block_given?
+      record = new(id)
+      record.instance_exec(record, &block) if block
       index[id] = record
     end
   end
@@ -53,17 +54,15 @@ module StaticAssociation
     def belongs_to_static(name, opts = {})
       class_name = opts.fetch(:class_name, name.to_s.camelize)
 
-      self.send(:define_method, name) do
-        begin
-          foreign_key = self.send("#{name}_id")
-          class_name.constantize.find(foreign_key) if foreign_key
-        rescue RecordNotFound
-          nil
-        end
+      send(:define_method, name) do
+        foreign_key = send("#{name}_id")
+        class_name.constantize.find(foreign_key) if foreign_key
+      rescue RecordNotFound
+        nil
       end
 
-      self.send(:define_method, "#{name}=") do |assoc|
-        self.send("#{name}_id=", assoc.id)
+      send(:define_method, "#{name}=") do |assoc|
+        send("#{name}_id=", assoc.id)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,12 @@
 # loaded once.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'bundler/setup'
+require "bundler/setup"
 
-require 'rspec/its'
+require "rspec/its"
 
-require 'static_association'
+require "static_association"
 
 RSpec.configure do |config|
-  config.order = 'random'
+  config.order = "random"
 end

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -1,22 +1,30 @@
-require 'spec_helper'
-require 'static_association'
+require "spec_helper"
+require "static_association"
+
+class DummyClass
+  include StaticAssociation
+  attr_accessor :name
+end
+
+class AssociationClass
+  attr_accessor :dummy_class_id
+  attr_accessor :dodo_class_id
+
+  extend StaticAssociation::AssociationHelpers
+  belongs_to_static :dummy_class
+  belongs_to_static :dodo_class, class_name: "DummyClass"
+end
 
 describe StaticAssociation do
-
-  class DummyClass
-    include StaticAssociation
-    attr_accessor :name
-  end
-
   after do
-    DummyClass.instance_variable_set("@index", {})
+    DummyClass.instance_variable_set(:@index, {})
   end
 
   describe ".record" do
     it "should add a record" do
       expect {
         DummyClass.record id: 1 do
-          self.name = 'asdf'
+          self.name = "asdf"
         end
       }.to change(DummyClass, :count).by(1)
     end
@@ -25,11 +33,11 @@ describe StaticAssociation do
       it "should raise an error with a duplicate id" do
         expect {
           DummyClass.record id: 1 do
-            self.name = 'asdf'
+            self.name = "asdf"
           end
 
           DummyClass.record id: 1 do
-            self.name = 'asdf'
+            self.name = "asdf"
           end
         }.to raise_error(StaticAssociation::DuplicateID)
       end
@@ -38,25 +46,24 @@ describe StaticAssociation do
     context "sets up the instance using self" do
       subject {
         DummyClass.record id: 1 do
-          self.name = 'asdf'
+          self.name = "asdf"
         end
       }
 
       its(:id) { should == 1 }
-      its(:name) { should == 'asdf' }
+      its(:name) { should == "asdf" }
     end
 
     context "sets up the instance using the object passed in" do
       subject {
         DummyClass.record id: 1 do |c|
-          c.name = 'asdf'
+          c.name = "asdf"
         end
       }
 
       its(:id) { should == 1 }
-      its(:name) { should == 'asdf' }
+      its(:name) { should == "asdf" }
     end
-
 
     context "without a block" do
       subject { DummyClass.record id: 1 }
@@ -77,7 +84,7 @@ describe StaticAssociation do
   describe "finders" do
     before do
       DummyClass.record id: 1 do
-        self.name = 'asdf'
+        self.name = "asdf"
       end
     end
 
@@ -114,15 +121,6 @@ describe StaticAssociation do
   end
 
   describe ".belongs_to_static" do
-    class AssociationClass
-      attr_accessor :dummy_class_id
-      attr_accessor :dodo_class_id
-
-      extend StaticAssociation::AssociationHelpers
-      belongs_to_static :dummy_class
-      belongs_to_static :dodo_class, class_name: 'DummyClass'
-    end
-
     let(:associated_class) { AssociationClass.new }
 
     it "creates reader method that uses the correct singularized class when finding static association" do

--- a/static_association.gemspec
+++ b/static_association.gemspec
@@ -1,21 +1,20 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'static_association/version'
+require "static_association/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "static_association"
-  spec.version       = StaticAssociation::VERSION
-  spec.authors       = ["Oliver Nightingale"]
-  spec.email         = ["oliver.nightingale1@gmail.com"]
-  spec.description   = %q{StaticAssociation adds a simple enum type that can act like an ActiveRecord association for static data.}
-  spec.summary       = %q{ActiveRecord like associations for static data}
-  spec.license       = "MIT"
-  spec.homepage      = "https://github.com/New-Bamboo/static_association"
+  spec.name = "static_association"
+  spec.version = StaticAssociation::VERSION
+  spec.authors = ["Oliver Nightingale"]
+  spec.email = ["oliver.nightingale1@gmail.com"]
+  spec.description = "StaticAssociation adds a simple enum type that can act like an ActiveRecord association for static data."
+  spec.summary = "ActiveRecord like associations for static data"
+  spec.license = "MIT"
+  spec.homepage = "https://github.com/New-Bamboo/static_association"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = `git ls-files`.split($/)
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport", ">= 6.0.0"
@@ -24,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "standard"
 end


### PR DESCRIPTION
Before, there were no linting checks on the codebase.

This adds the standard gem and a lint workflow to CI, so that the code
can be tidied up and kept consistent.