### PR TITLE
Update gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # StaticAssociation
 
-[![Build Status](https://travis-ci.org/New-Bamboo/static_association.png?branch=master)](https://travis-ci.org/New-Bamboo/static_association)
+![test](https://github.com/thoughtbot/static_association/actions/workflows/test.yml/badge.svg)
+![lint](https://github.com/thoughtbot/static_association/actions/workflows/lint.yml/badge.svg)
 
 Adds basic ActiveRecord-like associations to static data.
 
@@ -9,7 +10,7 @@ Adds basic ActiveRecord-like associations to static data.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'static_association'
+gem "static_association"
 ```
 
 And then execute:
@@ -61,6 +62,6 @@ This assumes your model has a field `day_id`.
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Run the tests (`rake`)
+4. Run lint checks and tests (`bundle exec rake`)
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create new Pull Request

--- a/static_association.gemspec
+++ b/static_association.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description = "StaticAssociation adds a simple enum type that can act like an ActiveRecord association for static data."
   spec.summary = "ActiveRecord like associations for static data"
   spec.license = "MIT"
-  spec.homepage = "https://github.com/New-Bamboo/static_association"
+  spec.homepage = "https://github.com/thoughtbot/static_association"
 
   spec.files = `git ls-files`.split($/)
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -19,9 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 6.0.0"
 
-  spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "rspec-its", "~> 1.2"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "standard"
 end


### PR DESCRIPTION
- Remove `rake` as a development dependency since it ships with Ruby by
  default
- Update information in gemspec
- Update information in readme