### PR TITLE
Add `.find_by`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ end
 
 Calling `record` will allow you to create an instance of this static model, a unique id is mandatory. The newly created object is yielded to the passed block.
 
-The `Day` class will gain an `all` and `find` method.
+The `Day` class will gain the `all`, `find` and `find_by` methods.
+
+- `find_by` finds the first record matching the specified conditions. If no record is found, returns `nil`.
 
 ### Associations
 

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -43,19 +43,7 @@ module StaticAssociation
     end
 
     def find_by(**args)
-      records = index.values
-
-      records.find do |record|
-        matches = args.map do |attribute, value|
-          if record.respond_to?(attribute)
-            record.send(attribute) == value
-          else
-            raise UndefinedAttribute
-          end
-        end
-
-        matches.all?
-      end
+      all.find { |record| matches_attributes?(record: record, attributes: args) }
     end
 
     def record(settings, &block)
@@ -65,6 +53,16 @@ module StaticAssociation
       record = new(id)
       record.instance_exec(record, &block) if block
       index[id] = record
+    end
+
+    private
+
+    def matches_attributes?(record:, attributes:)
+      attributes.all? do |attribute, value|
+        raise UndefinedAttribute unless record.respond_to?(attribute)
+
+        record.send(attribute) == value
+      end
     end
   end
 

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -7,6 +7,8 @@ require "active_support/core_ext/string/inflections"
 module StaticAssociation
   extend ActiveSupport::Concern
 
+  class ArgumentError < StandardError; end
+
   class DuplicateID < StandardError; end
 
   class RecordNotFound < StandardError; end
@@ -43,6 +45,8 @@ module StaticAssociation
     end
 
     def find_by(**args)
+      args.any? or raise ArgumentError
+
       all.find { |record| matches_attributes?(record: record, attributes: args) }
     end
 
@@ -59,7 +63,7 @@ module StaticAssociation
 
     def matches_attributes?(record:, attributes:)
       attributes.all? do |attribute, value|
-        raise UndefinedAttribute unless record.respond_to?(attribute)
+        record.respond_to?(attribute) or raise UndefinedAttribute
 
         record.send(attribute) == value
       end

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -11,6 +11,8 @@ module StaticAssociation
 
   class RecordNotFound < StandardError; end
 
+  class UndefinedAttribute < StandardError; end
+
   attr_reader :id
 
   private
@@ -38,6 +40,22 @@ module StaticAssociation
 
     def find_by_id(id)
       index[id]
+    end
+
+    def find_by(**args)
+      records = index.values
+
+      records.find do |record|
+        matches = args.map do |attribute, value|
+          if record.respond_to?(attribute)
+            record.send(attribute) == value
+          else
+            raise UndefinedAttribute
+          end
+        end
+
+        matches.all?
+      end
     end
 
     def record(settings, &block)

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -65,7 +65,7 @@ module StaticAssociation
       attributes.all? do |attribute, value|
         record.respond_to?(attribute) or raise UndefinedAttribute
 
-        record.send(attribute) == value
+        record.public_send(attribute) == value
       end
     end
   end

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -118,6 +118,29 @@ describe StaticAssociation do
         it { should be_nil }
       end
     end
+
+    describe ".find_by" do
+      context "record exists" do
+        subject { DummyClass.find_by(id: 1) }
+
+        it { should be_kind_of(DummyClass) }
+        its(:id) { should == 1 }
+      end
+
+      context "record does not exist" do
+        subject { DummyClass.find_by(id: 2) }
+
+        it { should be_nil }
+      end
+
+      context "with invalid attributes" do
+        it "raises a StaticAssociation::UndefinedAttribute" do
+          expect {
+            DummyClass.find_by(undefined_attribute: 1)
+          }.to raise_error(StaticAssociation::UndefinedAttribute)
+        end
+      end
+    end
   end
 
   describe ".belongs_to_static" do

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -133,11 +133,19 @@ describe StaticAssociation do
         it { should be_nil }
       end
 
-      context "with invalid attributes" do
+      context "with undefined attributes" do
         it "raises a StaticAssociation::UndefinedAttribute" do
           expect {
             DummyClass.find_by(undefined_attribute: 1)
           }.to raise_error(StaticAssociation::UndefinedAttribute)
+        end
+      end
+
+      context "with no attributes" do
+        it "raises a StaticAssociation::ArgumentError" do
+          expect {
+            DummyClass.find_by
+          }.to raise_error(StaticAssociation::ArgumentError)
         end
       end
     end


### PR DESCRIPTION
`find_by` finds the first record matching the specified conditions. If no record is found, returns nil.

This method follows the [Rails `.find_by`](https://api.rubyonrails.org/v6.1.4/classes/ActiveRecord/FinderMethods.html#method-i-find_by) behaviour.