### PR TITLE
Refactor specs

### DIFF
--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -56,9 +56,7 @@ module StaticAssociation
 
       send(:define_method, name) do
         foreign_key = send("#{name}_id")
-        class_name.constantize.find(foreign_key) if foreign_key
-      rescue RecordNotFound
-        nil
+        class_name.constantize.find_by_id(foreign_key)
       end
 
       send(:define_method, "#{name}=") do |assoc|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,6 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require "bundler/setup"
 
-require "rspec/its"
-
 require "static_association"
 
 RSpec.configure do |config|

--- a/static_association.gemspec
+++ b/static_association.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 6.0.0"
 
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "standard"
 end


### PR DESCRIPTION
This refactors the existing specs to bring them more inline with our typical
approach outlined in the [guides](https://github.com/thoughtbot/guides), leaning on the [Four Phase Test](https://thoughtbot.com/blog/four-phase-test) and [Let's Not](https://thoughtbot.com/blog/lets-not)
approaches.

The objective of this refactor is to make the tests more readable and accessible
for new contributors.

A dependency on `rspec-its` is also removed.

The `belongs_to_static` helper method is also refactored to use `.find_by_id`
(which returns `nil` for missing records) instead of `.find` and rescuing
`RecordNotFound` errors.