### PR TITLE
Add `.where` class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,24 @@ class Day
 end
 ```
 
-Calling `record` will allow you to create an instance of this static model, a unique id is mandatory. The newly created object is yielded to the passed block.
+Calling `record` will allow you to create an instance of this static model,
+a unique id is mandatory. The newly created object is yielded to the passed
+block.
 
-The `Day` class will gain an `all` and `find` method.
+The `Day` class will gain `.all`, `.find`, `.find_by_id`, and `.where` methods.
+
+- The `.all` method returns all the static records defined in the class.
+- The `.find` method accepts a single id and returns the matching record. If the
+  record does not exist, a `RecordNotFound` error is raised.
+- The `.find_by_id` method behaves similarly to the `.find` method, except it
+  returns `nil` when a record does not exist.
+- The `.where` method accepts an array of ids and returns all records with
+  matching ids.
 
 ### Associations
 
-Currently just a 'belongs to' association can be created. This behaviour can be mixed into an `ActiveRecord` model:
+Currently just a 'belongs to' association can be created. This behaviour can be
+mixed into an `ActiveRecord` model:
 
 ```ruby
 class Event < ActiveRecord::Base

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -40,6 +40,10 @@ module StaticAssociation
       index[id]
     end
 
+    def where(id: [])
+      all.select { |record| id.include?(record.id) }
+    end
+
     def record(settings, &block)
       settings.assert_valid_keys(:id)
       id = settings.fetch(:id)

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -124,6 +124,18 @@ RSpec.describe StaticAssociation do
     end
   end
 
+  describe ".where" do
+    it "returns all records with the given ids" do
+      record1 = DummyClass.record(id: 1)
+      _record2 = DummyClass.record(id: 2)
+      record3 = DummyClass.record(id: 3)
+
+      results = DummyClass.where(id: [1, 3, 4])
+
+      expect(results).to contain_exactly(record1, record3)
+    end
+  end
+
   describe ".belongs_to_static" do
     it "defines a reader method for the association" do
       associated_class = AssociationClass.new


### PR DESCRIPTION
This implements a `.where` method for retrieving an array of static records.

The method accepts an array of ids and returns an array of records.

Unlike the .find method, if a record does not exist for a given id, an
error is not raised.