### PR TITLE
Remove metadata["test_files"] from gemspec

### DIFF
--- a/static_association.gemspec
+++ b/static_association.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "standard"
-  spec.metadata["test_files"] = Dir.glob("test/**/*") + Dir.glob("spec/**/*") + Dir.glob("features/**/*")
 end


### PR DESCRIPTION
This entry was added after the [(soft) deprecation](https://github.com/rubygems/guides/issues/90#issuecomment-1143253417) of `spec.test_files` but metadata values are expected to be strings, not an array of file paths. So best to just removing the metadata entry entirely as it adds no tangible value.