### PR TITLE
Coerce #find_by_id argument to integer

### DIFF
--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -37,7 +37,9 @@ module StaticAssociation
     end
 
     def find_by_id(id)
-      index[id]
+      index[
+        Integer(id, exception: false) || id
+      ]
     end
 
     def where(id: [])

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -122,6 +122,46 @@ RSpec.describe StaticAssociation do
         expect(found_record).to be_nil
       end
     end
+
+    context "when id argument is a numeric string" do
+      it "returns the record" do
+        record = DummyClass.record(id: 1)
+
+        found_record = DummyClass.find_by_id("1")
+
+        expect(found_record).to eq(record)
+      end
+    end
+
+    context "when id argument is a non-numeric string" do
+      it "returns the record" do
+        DummyClass.record(id: 1)
+
+        found_record = DummyClass.find_by_id("foo")
+
+        expect(found_record).to be_nil
+      end
+    end
+
+    context "when record ids are strings and id argument matches a record" do
+      it "returns the record" do
+        record = DummyClass.record(id: "foo")
+
+        found_record = DummyClass.find_by_id("foo")
+
+        expect(found_record).to eq(record)
+      end
+    end
+
+    context "when record ids are strings and id argument doesn't match a record" do
+      it "returns nil" do
+        DummyClass.record(id: "foo")
+
+        found_record = DummyClass.find_by_id("bar")
+
+        expect(found_record).to be_nil
+      end
+    end
   end
 
   describe ".where" do


### PR DESCRIPTION
Ensures a matching record is found if passing a string representation of the id, avoiding the need to coerce the argument into a string beforehand.

E.g. `MyRecord.find_by_id("1")` returns matching `record(id: 1)`.

If the string does not coerce into an integer then the original string argument is used. To cater for use cases where non-numeric IDs are used for records.