### PR TITLE
Adds `.find_by` class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Calling `record` will allow you to create an instance of this static model,
 a unique id is mandatory. The newly created object is yielded to the passed
 block.
 
-The `Day` class will gain `.all`, `.find`, `.find_by_id`, and `.where` methods.
+The `Day` class will gain `.all`, `.find`, `.find_by_id`, `.find_by` and
+`.where` methods.
 
 - The `.all` method returns all the static records defined in the class.
 - The `.ids` method returns an array of all the ids of the static records.
@@ -51,6 +52,8 @@ The `Day` class will gain `.all`, `.find`, `.find_by_id`, and `.where` methods.
   record does not exist, a `RecordNotFound` error is raised.
 - The `.find_by_id` method behaves similarly to the `.find` method, except it
   returns `nil` when a record does not exist.
+- `find_by` finds the first record matching the specified conditions. If no
+  record is found, returns `nil`.
 - The `.where` method accepts an array of ids and returns all records with
   matching ids.
 

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -191,6 +191,99 @@ RSpec.describe StaticAssociation do
 
       expect(results).to contain_exactly(record1, record3)
     end
+
+    describe ".find_by" do
+      context "when record exists with the specified attribute value" do
+        it "returns the record" do
+          record1 = DummyClass.record(id: 1) do |r|
+            r.name = "foo"
+          end
+          _record2 = DummyClass.record(id: 2) do |r|
+            r.name = "bar"
+          end
+
+          found_record = DummyClass.find_by(name: "foo")
+
+          expect(found_record).to eq(record1)
+        end
+      end
+
+      context "when no record exists that matches the specified attribute value" do
+        it "returns nil" do
+          DummyClass.record(id: 1) do |r|
+            r.name = "foo"
+          end
+
+          found_record = DummyClass.find_by(name: "bar")
+
+          expect(found_record).to be_nil
+        end
+      end
+
+      context "when multiple records match the specified attribute value" do
+        it "returns the first matching record" do
+          record1 = DummyClass.record(id: 1) do |r|
+            r.name = "foo"
+          end
+          _record2 = DummyClass.record(id: 2) do |r|
+            r.name = "foo"
+          end
+
+          found_record = DummyClass.find_by(name: "foo")
+
+          expect(found_record).to eq(record1)
+        end
+      end
+
+      context "when specifying multiple attribute values" do
+        it "returns the record matching all attributes" do
+          _record1 = DummyClass.record(id: 1) do |r|
+            r.name = "foo"
+          end
+          record2 = DummyClass.record(id: 2) do |r|
+            r.name = "foo"
+          end
+
+          found_record = DummyClass.find_by(id: 2, name: "foo")
+
+          expect(found_record).to eq(record2)
+        end
+      end
+
+      context "when specifying multiple attribute values but no record " \
+              "matches all attributes" do
+        it "returns nil" do
+          _record1 = DummyClass.record(id: 1) do |r|
+            r.name = "foo"
+          end
+
+          found_record = DummyClass.find_by(id: 1, name: "bar")
+
+          expect(found_record).to be_nil
+        end
+      end
+
+      context "with undefined attributes" do
+        it "raises a StaticAssociation::UndefinedAttribute" do
+          DummyClass.record(id: 1)
+
+          expect {
+            DummyClass.find_by(undefined_attribute: 1)
+          }.to raise_error(
+            StaticAssociation::UndefinedAttribute,
+            "Undefined attribute 'undefined_attribute'"
+          )
+        end
+      end
+
+      context "with no attributes" do
+        it "raises a StaticAssociation::ArgumentError" do
+          expect {
+            DummyClass.find_by
+          }.to raise_error(StaticAssociation::ArgumentError)
+        end
+      end
+    end
   end
 
   describe ".belongs_to_static" do


### PR DESCRIPTION
Recreation of #14 by @Kizr.

---

The `.find_by` method accepts a hash of attributes and returns the first record that matches all of them. If no record was found, the method returns `nil`, this matches the Rails `.find_by` behaviour.

If an attribute is not valid for the record, an `UndefinedAttribute` error is raised.