### PR TITLE
Add .find_by! method

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The `Day` class will gain the following methods:
   `nil` when a record does not exist.
 - `.find_by`: finds the first record matching the specified conditions. If no
   record is found, returns `nil`.
+- `find_by!` behaves like `find_by` but raises a
+  `StaticAssociation::RecordNotFound` error if no record is found.
 - `.where`: accepts an array of ids and returns all records with matching ids.
 
 ### Associations

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -62,6 +62,13 @@ module StaticAssociation
       all.find { |record| matches_attributes?(record: record, attributes: args) }
     end
 
+    def find_by!(**args)
+      find_by(**args) or raise RecordNotFound.new(
+        "Couldn't find #{name} with " +
+        args.map { |k, v| "#{k}=#{v}" }.join(", ")
+      )
+    end
+
     def record(settings, &block)
       settings.assert_valid_keys(:id)
       id = settings.fetch(:id)


### PR DESCRIPTION
Behaves the same as `.find_by`, accepting one or more attributes to find a matching record by. The key difference is the method raises a `StaticAssociation::RecordNotFound` exception if no record is found.