### PR TITLE
Use including class name in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use including class name for error messages (#TODO)
+
 ## v0.2.0 (20 June 2025)
 
 ### Added

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -42,7 +42,7 @@ module StaticAssociation
 
     def find(id)
       find_by_id(id) or raise RecordNotFound.new(
-        "Couldn't find DummyClass with 'id'=#{id}"
+        "Couldn't find #{name} with 'id'=#{id}"
       )
     end
 

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -117,6 +117,13 @@ RSpec.describe StaticAssociation do
             StaticAssociation::RecordNotFound,
             "Couldn't find DummyClass with 'id'=1"
           )
+
+        stub_const("NewDummyClass", Class.new(DummyClass))
+        expect { NewDummyClass.find(1) }
+          .to raise_error(
+            StaticAssociation::RecordNotFound,
+            "Couldn't find NewDummyClass with 'id'=1"
+          )
       end
     end
 


### PR DESCRIPTION
Updates the error message generated by `find_by_id` to use the including class name instead of a static `DummyClass`